### PR TITLE
Modification to proposal and sample notebook flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+local.py
+*.swp
+*.swo

--- a/tbc/templates/base.html
+++ b/tbc/templates/base.html
@@ -206,6 +206,15 @@
         </center>
         <div class="clearfix"></div>
     {% endif %}
+    {% if cannot_submit_sample %}
+        <center>
+            <div class="alert" style="width:400px;height:25px;">
+                <a class="close" data-dismiss="alert" href="#">&times;</a>
+                <p>You have not been permitted to send sample notebook.</p>
+            </div>
+        </center>
+        <div class="clearfix"></div>
+    {% endif %}
     <div class="row-fluid">
         <center><h3>Recent Submissions</h3></center>
         {% for item in items %}

--- a/tbc/templates/tbc/review-proposal.html
+++ b/tbc/templates/tbc/review-proposal.html
@@ -8,16 +8,16 @@
     {% endif %}
     <ol>
     {% for proposal in proposals %}
-        <li><h4>Propsal from {{ proposal.user.user.first_name }} {{ proposal.user.user.last_name }}</h4></li>
-            <div class="accordion" id="accordion{{ forloop.counter }}">
+        <li><h4>Proposal from {{ proposal.user.user.first_name }} {{ proposal.user.user.last_name }}</h4></li>
+            <div class="accordion" id="accordion1{{ forloop.parentloop.counter }}{{ forloop.counter }}">
                 {% for textbook in proposal.textbooks.all %}
                     <div class="accordion-group">
                         <div class="accordion-heading">
-                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion{{ forloop.counter }}" href="#collapse{{forloop.counter}}">
+                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion1{{ forloop.parentloop.counter }}{{ forloop.counter }}" href="#collapse1{{ forloop.parentloop.counter }}{{forloop.counter}}">
                                 Book Preference {{ forloop.counter }} - {{ textbook.title }}
                             </a>
                         </div>
-                        <div id="collapse{{forloop.counter}}" class="accordion-body collapse">
+                        <div id="collapse1{{ forloop.parentloop.counter }}{{forloop.counter}}" class="accordion-body collapse">
                             <div class="accordion-inner">
                                 Author: {{ textbook.author}}<br>
                                 Edition: {{ textbook.edition }}<br>
@@ -40,16 +40,16 @@
     <hr>
     <ol>
     {% for proposal in old_proposals %}
-        <h4><li>Propsal from {{ proposal.proposal.user.user.first_name }} {{ proposal.proposal.user.user.last_name }}</h4></li>
-            <div class="accordion" id="accordion{{ forloop.counter }}">
+        <h4><li>Proposal from {{ proposal.proposal.user.user.first_name }} {{ proposal.proposal.user.user.last_name }}</h4></li>
+            <div class="accordion" id="accordion2{{ forloop.counter }}">
                 {% for textbook in proposal.proposal.textbooks.all %}
                     <div class="accordion-group">
                         <div class="accordion-heading">
-                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion{{ forloop.counter }}" href="#collapse{{forloop.counter}}">
+                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2{{ forloop.parentloop.counter }}{{ forloop.counter }}" href="#collapse2{{ forloop.parentloop.counter }}{{forloop.counter}}">
                                 Book Preference {{ forloop.counter }} - {{ textbook.title }}
                             </a>
                         </div>
-                        <div id="collapse{{forloop.counter}}" class="accordion-body collapse">
+                        <div id="collapse2{{ forloop.parentloop.counter }}{{forloop.counter}}" class="accordion-body collapse">
                             <div class="accordion-inner">
                                 Author: {{ textbook.author}}<br>
                                 Edition: {{ textbook.edition }}<br>

--- a/tbc/templates/tbc/submit-sample.html
+++ b/tbc/templates/tbc/submit-sample.html
@@ -29,7 +29,7 @@ function validate_content()
     {% if has_old %}
         <form action="/submit-sample/{{ proposal.id }}/{{ old_notebook.id }}" name="with-old" method=POST enctype="multipart/form-data" onSubmit="return validate_content();">
         {% csrf_token %}
-            <input type=text id=ch_name_old name=ch_name_old placeholder="{{ old_notebook.title }}">
+            <input type=text id=ch_name_old name=ch_name_old value="{{ old_notebook.name }}">
             <input type=file id=old_notebook name=old_notebook>
         <br>
         <hr>


### PR DESCRIPTION
After the proposal is rejected, user will again submit the proposal.
So the proposal form is filled with the initial values of the rejected
proposal.

Sample notebook can be submitted only if the proposal is approved else
will display a message saying 'not permitted'

User after sample notebook submission can anytime edit it.

Modified the template for the reviewer to see the new and old proposal.
Since the ids where same for the collapse element in the loop so there
was problem in javascript.

Profile view modified.
First checks for the user profile. If exists then updates or else
creates a new profile for the user. This will prevent multiple profile
for a single user.[Alternatively, we can give one-to-one relation between
user and profile in models]
